### PR TITLE
Better metadata for errors and variables

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,9 @@ export default class ApolloLinkTracer extends ApolloLink {
               span.setMeta({
                 [`error${index ? index + 1 : ''}.name`]: error.name,
                 [`error${index ? index + 1 : ''}.message`]: error.message,
-                [`error${index ? index + 1 : ''}.path`]: error.path!.join(''),
+                [`error${index ? index + 1 : ''}.path`]: error.path
+                  ? error.path.join('')
+                  : '',
               });
             });
           }

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -63,9 +63,9 @@ describe(`ApolloLinkTracer`, () => {
       }),
     ]);
 
-    execute(link, request1).subscribe(result => {
+    execute(link, request1).subscribe(async result => {
       expect(called).to.be.eq(1);
-      reporter.flushIfNeeded();
+      await reporter.flushIfNeeded();
       expect(stub).to.have.been.called;
       done();
       return null;
@@ -101,9 +101,9 @@ describe(`ApolloLinkTracer`, () => {
       }),
     ]);
 
-    execute(link, request1).subscribe(result => {
+    execute(link, request1).subscribe(async result => {
       expect(called).to.be.eq(1);
-      reporter.flushIfNeeded();
+      await reporter.flushIfNeeded();
       expect(stub).to.not.have.been.called;
       done();
       return null;


### PR DESCRIPTION
More specific metadata for GQL errors and variables, makes understanding error traces easier.