### PR TITLE
Add tag support

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     ]
   },
   "dependencies": {
-    "@convoy/tracer": "^0.0.93",
+    "@convoy/tracer": "^1.0.144",
     "apollo-link": "^1.1.0",
     "tslib": "^1.6.0"
   },

--- a/test/unit/index.ts
+++ b/test/unit/index.ts
@@ -31,7 +31,7 @@ describe(`ApolloLinkTracer`, () => {
     tracer = new ApolloLinkTracer({
       service: 'my-service',
       tracerConfig: {
-        fullTraceSampleRate: 1,
+        sampleRate: 1,
         reporter,
       },
     });


### PR DESCRIPTION
Tagging allows us to segment metrics, such as seeing the count of errors by name or segmenting error rates by scene. This adds tagging support for traced apollo queries.